### PR TITLE
added FXGL Easter egg, updated javafx version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mainClass>com.fluffy.luffs.weight.converter.WeightConverter</mainClass>
-        <javafx.version>[14.0,14.1)</javafx.version>
-        <gluon.attach>4.0.8</gluon.attach>
+        <javafx.version>16</javafx.version>
+        <fxgl.version>dev-SNAPSHOT</fxgl.version>
+        <gluon.attach>4.0.9</gluon.attach>
         <graalVMVersion>20.3.0-dev</graalVMVersion>
         <ios.release.providedSigningIdentity/>
         <ios.release.providedProvisioningProfile/>
@@ -188,6 +189,11 @@
             <version>${javafx.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.github.almasb</groupId>
+            <artifactId>fxgl</artifactId>
+            <version>${fxgl.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.gluonhq.attach</groupId>
             <artifactId>lifecycle</artifactId>
             <version>${gluon.attach}</version>
@@ -244,6 +250,11 @@
     </profiles>
     
     <repositories>
+        <repository>
+            <id>oss.sonatype.org-snapshot</id>
+            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+        </repository>
+
         <repository>
             <id>Gluon</id>
             <url>https://nexus.gluonhq.com/nexus/content/repositories/releases</url>

--- a/src/main/java/com/fluffy/luffs/weight/converter/WeightConverter.java
+++ b/src/main/java/com/fluffy/luffs/weight/converter/WeightConverter.java
@@ -24,11 +24,22 @@ SOFTWARE.
 
 package com.fluffy.luffs.weight.converter;
 
+import com.almasb.fxgl.animation.Interpolators;
+import com.almasb.fxgl.app.ApplicationMode;
+import com.almasb.fxgl.app.GameApplication;
+import com.almasb.fxgl.app.GameSettings;
+import com.almasb.fxgl.core.math.FXGLMath;
+import com.almasb.fxgl.dsl.FXGL;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
+import javafx.geometry.Point2D;
 import javafx.scene.Scene;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
+import javafx.util.Duration;
 
 /**
  * Weight Converter
@@ -42,11 +53,39 @@ public class WeightConverter extends Application {
         AnchorPane root = FXMLLoader.load(this.getClass().getResource("/fxml/Main.fxml"));
         Scene scene = new Scene(root);
 
+        addEasterEggHandler(root);
+
         scene.getStylesheets()
                 .add(this.getClass().getResource("/css/Style.css").toExternalForm());
         stage.setScene(scene);
 
         stage.show();
+    }
+
+    private void addEasterEggHandler(AnchorPane root) {
+        GameApplication.embeddedLaunch(new GameApplication() {
+            @Override
+            protected void initSettings(GameSettings settings) {
+                settings.setApplicationMode(ApplicationMode.RELEASE);
+            }
+        });
+
+        VBox vbox = (VBox) root.getChildren().get(0);
+
+        root.getScene().addEventHandler(KeyEvent.KEY_PRESSED, event -> {
+            if (event.isControlDown() && event.getCode().equals(KeyCode.DIGIT4)) {
+
+                FXGL.animationBuilder()
+                        .duration(Duration.seconds(1))
+                        .interpolator(Interpolators.BOUNCE.EASE_OUT())
+                        .autoReverse(true)
+                        .repeat(2)
+                        .translate(FXGLMath.random(vbox.getChildren()).get())
+                        .from(Point2D.ZERO)
+                        .to(new Point2D(300, 0))
+                        .buildAndPlay();
+            }
+        });
     }
 
     public static void main(String[] args) {

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -31,6 +31,8 @@ module WeightConverter {
     requires javafx.graphics;
     requires javafx.fxmlEmpty;
     requires javafx.fxml;
+
+    requires com.almasb.fxgl.all;
     
     requires com.gluonhq.attach.util;
     requires com.gluonhq.attach.storage;


### PR DESCRIPTION
For the mobile version to work, we will also need to update the client plugin configuration with [this reflectionList](https://github.com/AlmasB/FXGLGames/blob/5c58d3767609caaf20bd573ce818602ad4cefa0a/Breakout/pom.xml#L106). Given this easter egg is just a test, perhaps this PR should not be merged, or merged into a different branch.